### PR TITLE
Fix heading styles in about page and salon page

### DIFF
--- a/about.html
+++ b/about.html
@@ -145,7 +145,7 @@
     <div class="container mt-4">
         <div class="section_title">
             <h3 class="title">
-              About <span style="color: red; font-weight: bold;">Ted<sup>X</sup></span><span style="text-transform: none">NITKSurathkal</span>
+              About <span style="color: red; font-weight: bold;">Ted<sup>X</sup></span><span style="font-size: 0;"> </span><span style="text-transform: none">NITKSurathkal</span>
             </h3>
         </div>
 

--- a/salon.html
+++ b/salon.html
@@ -100,12 +100,12 @@
               <a class="nav-link" href="/"><strong>Home</strong></a>
             </li>
             <li class="nav-item">
-              <a class="nav-link " href="/about"
-                ><strong>About</strong></a
-              >
+              <a class="nav-link" href="/about"><strong>About</strong></a>
             </li>
             <li class="nav-item">
-                <a class="nav-link active" href="/salon"><strong>Salon</strong></a>
+              <a class="nav-link active" href="/salon"
+                ><strong>Salon</strong></a
+              >
             </li>
             <li class="nav-item">
               <a class="nav-link" href="/past-editions"
@@ -147,8 +147,7 @@
           <div class="col-12">
             <div class="inner_cover_content">
               <h3 class="title">
-                <span style="color: red; font-weight: bold;"
-                  >Ted<sup>X</sup></span >NITKSurathkalSalon
+                Salon
               </h3>
             </div>
           </div>
@@ -169,24 +168,42 @@
       <div class="container">
         <div class="section_title">
           <h3 class="title">
-            What is <img src="/assets/img/tedx_salon.png" height="100px;">
+            What is <img src="/assets/img/tedx_salon.png" height="100px;" />
           </h3>
         </div>
 
         <div class="row justify-content-center">
           <div class="col-12 col-md-12">
             <p>
-                TEDx Salons engage the community during the time period between our main TEDx events, an opportunity for a fruitful discussion about brewing issues within the society. Limited in size, this serves as a platform for an intimate discussion with both the speakers as well as your peers. What makes TEDx salons unique is the level of attention given to diversity and inclusion both in terms of people, ideas, and venues.
+              TEDx Salons engage the community during the time period between
+              our main TEDx events, an opportunity for a fruitful discussion
+              about brewing issues within the society. Limited in size, this
+              serves as a platform for an intimate discussion with both the
+              speakers as well as your peers. What makes TEDx salons unique is
+              the level of attention given to diversity and inclusion both in
+              terms of people, ideas, and venues.
             </p>
             <p>
-                We’re hosting a virtual salon with live speakers who will delve deep into the chosen topic, sharing their journey, ideas and insights based on personal experiences. For the first time ever, the audience of the event will be given an opportunity to interact freely with the Speakers after the talk through an in-depth, moderated, Q&A session. The salon will then host members of the NITK community who will entwine the Speakers' perspectives with our community's ideology and goals through discussions on the chosen theme.
+              We’re hosting a virtual salon with live speakers who will delve
+              deep into the chosen topic, sharing their journey, ideas and
+              insights based on personal experiences. For the first time ever,
+              the audience of the event will be given an opportunity to interact
+              freely with the Speakers after the talk through an in-depth,
+              moderated, Q&A session. The salon will then host members of the
+              NITK community who will entwine the Speakers' perspectives with
+              our community's ideology and goals through discussions on the
+              chosen theme.
             </p>
             <p>
-                The purpose of TEDxNITKSurathkalSalon is to understand the essence of TED’s “Ideas Worth Sharing” and implement it in order to spark action. It is a chance for you to candidly introduce and discuss your thoughts, paving way for a fresh perspective. So, are you ready for a quality discussion?
+              The purpose of TEDxNITKSurathkalSalon is to understand the essence
+              of TED’s “Ideas Worth Sharing” and implement it in order to spark
+              action. It is a chance for you to candidly introduce and discuss
+              your thoughts, paving way for a fresh perspective. So, are you
+              ready for a quality discussion?
             </p>
           </div>
         </div>
-      </div>     
+      </div>
     </section>
     <!--about section end -->
 
@@ -194,9 +211,9 @@
     <section id="faq">
       <div class="container">
         <div class="section_title">
-            <h3 class="title" style="text-transform: none;">
-              FAQ's
-            </h3>
+          <h3 class="title" style="text-transform: none;">
+            FAQ's
+          </h3>
         </div>
 
         <div class="row justify-content-center">
@@ -376,10 +393,18 @@
 
     <script>
       // Generate FAQ accordion
-      $(function() {
-        for (var i = 0; i < faq_questions.length; i++)
-        {
-          html = "<li><a data-toggle='collapse' class='collapsed' href='#faq" + i + "'>" + faq_questions[i][0] + "<i class='fa fa-minus-circle'></i></a><div id='faq" + i + "' class='collapse' data-parent='#faq-list'><p>" + faq_questions[i][1] + "</p></div></li>"
+      $(function () {
+        for (var i = 0; i < faq_questions.length; i++) {
+          html =
+            "<li><a data-toggle='collapse' class='collapsed' href='#faq" +
+            i +
+            "'>" +
+            faq_questions[i][0] +
+            "<i class='fa fa-minus-circle'></i></a><div id='faq" +
+            i +
+            "' class='collapse' data-parent='#faq-list'><p>" +
+            faq_questions[i][1] +
+            "</p></div></li>";
 
           $("#faq-list").append(html);
         }
@@ -400,3 +425,4 @@
       gtag("config", "UA-110715968-3");
     </script>
   </body>
+</html>


### PR DESCRIPTION
Changes:
 - Changed main header in the salon page to Salon from TEDxNITKSurathkalSalon
 - Added a zero width space to TEDxNITKSurathkal subheader in about page to make the NITKSurathkal go to next line on mobile screens
![Screenshot from 2020-07-16 12-26-54](https://user-images.githubusercontent.com/47755579/87637871-7dd32980-c760-11ea-9610-47eec6289b53.png)
![Screenshot from 2020-07-16 12-27-15](https://user-images.githubusercontent.com/47755579/87637911-8c214580-c760-11ea-9160-273f956a8c71.png)
