### PR TITLE
Remove signature section from multiple pages for a cleaner design

### DIFF
--- a/about.html
+++ b/about.html
@@ -218,12 +218,6 @@
                     This independent TEDx event is operated under license from
                     <a href="https://www.ted.com" target="_blank">TED</a>.
                 </p>
-                <p class="signature">
-                    <a href="https://www.linkedin.com/in/appaji-dheeraj" target="_blank">
-                        ✦✦ ^_^ ✦✦ Redesigned by <span>Appaji Dheeraj</span>
-                    </a>
-                </p>
-
             </div>
 
         </div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2666,7 +2666,7 @@ body {
 }
 
 .image-bg {
-    background-color: #ffffff;
+    background-color: #2a2929;
     padding: 8px;
     width: 250px;
     height: 275px;
@@ -3368,11 +3368,13 @@ body {
 }
 
 /* Main Grid Layout */
+
 .speakers-grid {
-    display: grid;
-    grid-template-columns: 1fr; /* Single column on mobile */
-    gap: 80px;
-    align-items: center;
+  display: flex;
+  justify-content: center;   /* Centers horizontally */
+  align-items: center;       /* Centers vertically */
+  flex-direction: column;    /* Stacks text and future image vertically */
+  text-align: center;        /* Centers text inside */
 }
 
 /* Left Column: Text Content */

--- a/contact.html
+++ b/contact.html
@@ -219,11 +219,6 @@
                     This independent TEDx event is operated under license from
                     <a href="https://www.ted.com" target="_blank">TED</a>.
                 </p>
-                <p class="signature">
-                    <a href="https://www.linkedin.com/in/appaji-dheeraj" target="_blank">
-                        ✦✦ ^_^ ✦✦ Redesigned by <span>Appaji Dheeraj</span>
-                    </a>
-                </p>
             </div>
         </div>
     </footer>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <meta property="og:site_name" content="TEDxNITKSurathkal | Ideas Worth Spreading">
     <meta property="og:title" content="TEDxNITKSurathkal | Ideas Worth Spreading">
     <meta property="og:description"
-        content="TEDxNITKSurathkal is coming back for Edition 2023! See you on 17th November 2023.">
+        content="TEDxNITKSurathkal is coming back for Edition 2025! See you soon.">
     <meta property="og:url" content="http://www.tedxnitksurathkal.in/">
     <meta property="og:image" content="http://www.tedxnitksurathkal.in/assets/img/favicon.png">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
@@ -187,7 +187,7 @@
                 <!-- Left Column: Event Image -->
                 <div class="event-image-container">
                     <div class="image-bg">
-                        <img src="/assets/img/Home.png" alt="Event Logo" class="event-image">
+                        <img src="/assets/img/loader.png" alt="Event Logo" class="event-image">
                     </div>
                 </div>
 
@@ -349,7 +349,7 @@
         <div class="container">
 
             <!-- Section Title -->
-            <div class="section-title">
+            <div class="section-title" style="align-items: center;justify-content:center;text-align: center;">
                 <h2>OUR <span class="text-red">SPEAKERS</span></h2>
                 <div class="title-underline"></div>
                 <p class="subtitle">
@@ -372,13 +372,13 @@
                 </div>
 
                 <!-- Right Column: Image Placeholder -->
-                <div class="image-placeholder">
+                <!-- <div class="image-placeholder">
                     <div class="blur-bg-glow"></div>
                     <img src="assets/img/think.png" alt="A silhouette representing an upcoming speaker"
                         class="speaker-image">
                     <div class="decorative-blur-1"></div>
                     <div class="decorative-blur-2"></div>
-                </div>
+                </div> -->
             </div>
 
         </div>
@@ -471,7 +471,7 @@
     <!-- ======================================================== -->
     <!-- FINAL TRIBUTE SECTION (WITH FULL ORIGINAL TEXT) -->
     <!-- ======================================================== -->
-    <section class="tribute-section">
+    <section class="tribute-section" style="display: none;">
         <div class="container">
             <!-- Section Title -->
             <div class="section-title">
@@ -658,11 +658,6 @@
                     <script>document.write(new Date().getFullYear());</script> TEDxNITKSurathkal. All rights reserved.
                     This independent TEDx event is operated under license from
                     <a href="https://www.ted.com" target="_blank">TED</a>.
-                </p>
-                <p class="signature">
-                    <a href="https://www.linkedin.com/in/appaji-dheeraj" target="_blank">
-                        ✦✦ ^_^ ✦✦ Redesigned by <span>Appaji Dheeraj</span>
-                    </a>
                 </p>
 
             </div>

--- a/partners.html
+++ b/partners.html
@@ -198,12 +198,6 @@
                     This independent TEDx event is operated under license from
                     <a href="https://www.ted.com" target="_blank">TED</a>.
                 </p>
-                <p class="signature">
-                    <a href="https://www.linkedin.com/in/appaji-dheeraj" target="_blank">
-                        ✦✦ ^_^ ✦✦ Redesigned by <span>Appaji Dheeraj</span>
-                    </a>
-                </p>
-
             </div>
 
         </div>

--- a/past-editions.html
+++ b/past-editions.html
@@ -763,12 +763,6 @@
                     This independent TEDx event is operated under license from
                     <a href="https://www.ted.com" target="_blank">TED</a>.
                 </p>
-                <p class="signature">
-                    <a href="https://www.linkedin.com/in/appaji-dheeraj" target="_blank">
-                        ✦✦ ^_^ ✦✦ Redesigned by <span>Appaji Dheeraj</span>
-                    </a>
-                </p>
-
             </div>
 
         </div>

--- a/salon.html
+++ b/salon.html
@@ -267,12 +267,6 @@
                     This independent TEDx event is operated under license from
                     <a href="https://www.ted.com" target="_blank">TED</a>.
                 </p>
-                <p class="signature">
-                    <a href="https://www.linkedin.com/in/appaji-dheeraj" target="_blank">
-                        ✦✦ ^_^ ✦✦ Redesigned by <span>Appaji Dheeraj</span>
-                    </a>
-                </p>
-
             </div>
 
         </div>

--- a/talk-archives.html
+++ b/talk-archives.html
@@ -765,12 +765,6 @@
                     This independent TEDx event is operated under license from
                     <a href="https://www.ted.com" target="_blank">TED</a>.
                 </p>
-                <p class="signature">
-                    <a href="https://www.linkedin.com/in/appaji-dheeraj" target="_blank">
-                        ✦✦ ^_^ ✦✦ Redesigned by <span>Appaji Dheeraj</span>
-                    </a>
-                </p>
-
             </div>
 
         </div>

--- a/team.html
+++ b/team.html
@@ -224,11 +224,6 @@
                     This independent TEDx event is operated under license from
                     <a href="https://www.ted.com" target="_blank">TED</a>.
                 </p>
-                <p class="signature">
-                    <a href="https://www.linkedin.com/in/appaji-dheeraj" target="_blank">
-                        ✦✦ ^_^ ✦✦ Redesigned by <span>Appaji Dheeraj</span>
-                    </a>
-                </p>
 
             </div>
 


### PR DESCRIPTION
This pull request updates the TEDxNITKSurathkal website for the upcoming 2025 edition and makes several design and content improvements. The main changes include updating event information, refining the visual design, and removing personal attribution from the site footer across multiple pages.

**Event and Content Updates:**

* Updated the Open Graph description in `index.html` to announce the 2025 edition of TEDxNITKSurathkal.
* Changed the event image on the homepage from `Home.png` to `loader.png` in `index.html`.
* Hid the tribute section by setting its display to none in `index.html`.
* Commented out the speaker image placeholder in the "Meet The Minds Shaping Our Future" section of `index.html`.

**Design and Layout Improvements:**

* Improved section title alignment and centering for the speakers section in `index.html`.
* Changed the background color of `.image-bg` in `assets/css/main.css` from white to dark gray for better visual contrast.
* Refactored the `.speakers-grid` layout in `assets/css/main.css` from a grid to a flexbox for better responsiveness and centering.

**Footer Attribution Removal:**

* Removed the "Redesigned by Appaji Dheeraj" signature from the footer across all major pages: `index.html`, `about.html`, `contact.html`, `partners.html`, `past-editions.html`, `salon.html`, `talk-archives.html`, and `team.html`. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L662-L666) [[2]](diffhunk://#diff-2212b84a2a6ffe239872c76d266680d86f2438391034b2eb19604f17104f6968L221-L226) [[3]](diffhunk://#diff-eb5639ef0321321f5581e73866a7db6fb2c6d9d2fdbebafc7445f538e7078309L222-L226) [[4]](diffhunk://#diff-3c3123f40626bb1ff6159cb3d21bced8bf42c229c6d292ae3ccf3e22187e4db8L201-L206) [[5]](diffhunk://#diff-89b784a715a8331eb428d467eff418b3f9c2ee6eaf01c52cd36eeb860cda65a4L766-L771) [[6]](diffhunk://#diff-402febfbf1110935d5f1e809bd7ce7b38c43bd538ff4293ce1b05da55997b452L270-L275) [[7]](diffhunk://#diff-e8c67c768b22ac7b62c473a6eaca7f91fe4f3715798bb61e9b28310997b70e67L768-L773) [[8]](diffhunk://#diff-c8f56163f636b17a1f4e972ff446aeea02843c583823713129384f50e50d5b71L227-L231)